### PR TITLE
Fix sandbox error message

### DIFF
--- a/lib/server-code/runners/tasks/sandbox.js
+++ b/lib/server-code/runners/tasks/sandbox.js
@@ -25,11 +25,9 @@ exports.apply = applicationId => {
   try {
     process.setuid(appUid)
   } catch (e) {
-    if (logger.verbose) {
-      logger.error(e.message)
-    }
+    logger.error(e.message)
 
-    throw new Error('Internal error. Unable to run server code in sandbox.')
+    throw new Error('Failed to run code in sandbox on behalf of application\'s system user.')
   }
 
   applied = true


### PR DESCRIPTION
- fix sandbox error message
- always log an error on setup `process.setuid(appUid)`