### PR TITLE
improve the performance of json stringification

### DIFF
--- a/lib/util/json.js
+++ b/lib/util/json.js
@@ -13,7 +13,8 @@ const DATES_FIELD = '___dates___'
  * @returns {String}
  */
 exports.stringify = function(value, space) {
-  const seen = []
+  const seen = new Map()
+  let incr = 0
 
   return JSON.stringify(value, (k, v) => {
     if (v) {
@@ -31,12 +32,12 @@ exports.stringify = function(value, space) {
           }
         }
 
-        const seenIndex = seen.indexOf(v)
+        const seenIndex = seen.get(v)
 
-        if (seenIndex !== -1) {
+        if (seenIndex !== undefined) {
           v = { [OBJECTREF_FIELD]: seenIndex }
         } else {
-          seen.push(v)
+          seen.set(v, incr++)
         }
       }
     }


### PR DESCRIPTION
I have faced big performance issues with serialising a huge API service response
Fixed this by using a Map instead of Array to keep processed objects registry.
In fact the O(n) complexity is replaced by O(1)