### PR TITLE
- add pre running idle workers

### DIFF
--- a/bin/coderunner.json
+++ b/bin/coderunner.json
@@ -5,6 +5,7 @@
       "limit": 20
     },
     "concurrent": 4,
+    "minIdle": 2,
     "heartbeat": {
       "interval": 5,
       "timeout": 10

--- a/lib/cli/defaults.json
+++ b/lib/cli/defaults.json
@@ -2,6 +2,7 @@
   "workers": {
     "cache": false,
     "concurrent": 4,
+    "minIdle": 4,
     "heartbeat": {
       "interval": 5,
       "timeout": 10

--- a/lib/server-code/runners/cloud-master.js
+++ b/lib/server-code/runners/cloud-master.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const logger = require('../../util/logger')
+const { hrtime } = require('../../util/date')
 const MessagesBroker = require('../services/messages-broker')
 const WorkersBroker = require('./cloud-workers-broker')
 const managementServer = require('../services/management-server')
@@ -97,6 +98,10 @@ module.exports = class CloudMaster {
       this.taskRequests[tasksChannel] = Promise.resolve()
         .then(() => this.messageBroker.getTask(tasksChannel))
         .then(async task => {
+          task.getProcessingDuration = hrtime()
+
+          logger.debug(`Received a new task with id=${task.id}`)
+
           task = Object.assign(task, { cacheable: tasksExecutor.isTaskCacheable(task) })
 
           const resetRequestBefore = this.workersBroker.getAvailableWorkersCount() > 2
@@ -105,7 +110,14 @@ module.exports = class CloudMaster {
             this.taskRequests[tasksChannel] = null
           }
 
+          const getFindingWorkerTime = hrtime()
+
           const worker = await this.workersBroker.getWorkerForTask(task.applicationId, task.cacheable)
+
+          logger.debug(
+            `[${worker.process.pid}] found an available worker in ${getFindingWorkerTime()}ms ` +
+            `for task with id=${task.id}, the worker has been started in ${worker.startedIn}ms`
+          )
 
           if (!resetRequestBefore) {
             this.taskRequests[tasksChannel] = null
@@ -119,6 +131,12 @@ module.exports = class CloudMaster {
 
   async onTaskProcessed(task, result) {
     await this.messageBroker.setTaskResult(task, result)
+
+    if (task.getProcessingDuration) {
+      logger.debug(
+        `[${task.workerPID}] The task result has been sent in ${task.getProcessingDuration()} after getting the task`
+      )
+    }
   }
 
   exitOnError(error) {

--- a/lib/server-code/runners/cloud-worker.js
+++ b/lib/server-code/runners/cloud-worker.js
@@ -53,14 +53,11 @@ const flushPendingLogs = async () => {
  */
 const executeTask = async task => {
   try {
-    const time = process.hrtime()
+    const getExecuteTime = hrtime()
 
     const taskResult = await tasksExecutor.execute(task, RunOptions)
 
-    const duration = process.hrtime(time)
-    const ms = duration[0] * 1000 + duration[1] / 1e6
-
-    logger.info(`Processing finished in ${ms.toFixed(3)}ms`)
+    logger.info(`Processing finished in ${getExecuteTime()}ms`)
 
     await processSend({ processed: true, taskResult })
 

--- a/lib/server-code/runners/cloud-workers-broker.js
+++ b/lib/server-code/runners/cloud-workers-broker.js
@@ -40,13 +40,17 @@ class WorkersBroker extends EventEmitter {
 
     this.status = Status.GOOD
 
-    this.workerRunOptions = workerRunOptions
+    this.WORKER_RUN_OPTIONS = JSON.stringify(workerRunOptions)
 
     this.options = options
 
     this.heartbeatTimeout = this.options.heartbeat.timeout * 1000
 
     this.concurrentWorkersLimit = this.options.concurrent || OS.cpus().length
+
+    this.minIdleWorkersCount = this.options.minIdle || 0
+    this.minIdleWorkersCount = Math.max(this.minIdleWorkersCount, 0)
+    this.minIdleWorkersCount = Math.min(this.minIdleWorkersCount, this.concurrentWorkersLimit)
 
     if (this.options.cache) {
       if (this.options.cache === true) {
@@ -56,6 +60,8 @@ class WorkersBroker extends EventEmitter {
       this.cachedWorkersLimit = this.options.cache.limit
     }
 
+    this.startingWorkersCount = 0
+
     this.idleWorkers = []
     this.cachedWorkers = []
     this.busyWorkers = []
@@ -63,8 +69,18 @@ class WorkersBroker extends EventEmitter {
     cluster.on('exit', this.onWorkerExit.bind(this))
     cluster.on('message', this.onWorkerMessage.bind(this))
 
+    this.keepMinIdleWorkersCount()
+
     this.startWorkersHeartbeatTimer()
     this.startStatusWatcher()
+  }
+
+  keepMinIdleWorkersCount() {
+    const requireWorkersCount = this.minIdleWorkersCount - this.idleWorkers.length - this.startingWorkersCount
+
+    for (let i = 0; i < requireWorkersCount; i++) {
+      this.startNewWorker()
+    }
   }
 
   async stop() {
@@ -142,10 +158,12 @@ class WorkersBroker extends EventEmitter {
     const time = timeMarker()
 
     const worker = cluster.fork({
-      RUN_OPTIONS: JSON.stringify(this.workerRunOptions)
+      RUN_OPTIONS: this.WORKER_RUN_OPTIONS
     })
 
     worker.heartbeat = Date.now()
+
+    this.startingWorkersCount++
 
     try {
       await new Promise(resolve => {
@@ -170,13 +188,17 @@ class WorkersBroker extends EventEmitter {
         }
       })
 
-      logger.info(`[${worker.process.pid}] Worker started in ${time()}`)
+      worker.startedIn = time()
+
+      logger.info(`[${worker.process.pid}] Worker started in ${worker.startedIn}`)
 
       this.relocateWorker(worker, this.idleWorkers)
 
     } catch (error) {
       this.killWorker(worker, error.message)
     }
+
+    this.startingWorkersCount--
   }
 
   processTask(task, worker) {
@@ -283,6 +305,10 @@ class WorkersBroker extends EventEmitter {
           this.emit(Events.READY_FOR_NEXT_TASK)
         })
       }
+    }
+
+    if (!this.stopper && (oldPlace === this.idleWorkers || newPlace === this.busyWorkers)) {
+      this.keepMinIdleWorkersCount()
     }
   }
 
@@ -399,29 +425,32 @@ function timeMarker() {
 
 function getKilledWorkerDetails(worker) {
   const { appId, task } = worker
+
   const details = [`appId: ${appId}`]
 
-  if (task.deploymentModelName) {
-    details.push(`model: ${task.deploymentModelName}`)
-  }
+  if (task) {
+    if (task.deploymentModelName) {
+      details.push(`model: ${task.deploymentModelName}`)
+    }
 
-  if (task.className) {
-    const service = task.className.replace('services.', '')
-    details.push(`service: ${service}`)
-  }
+    if (task.className) {
+      const service = task.className.replace('services.', '')
+      details.push(`service: ${service}`)
+    }
 
-  if (task.method) {
-    details.push(`method: ${task.method}`)
-  }
+    if (task.method) {
+      details.push(`method: ${task.method}`)
+    }
 
-  if (task.eventId) {
-    const event = ServerCodeEvents.get(task.eventId)
+    if (task.eventId) {
+      const event = ServerCodeEvents.get(task.eventId)
 
-    details.push(`handler: ${event.provider.id}(${event.provider.id === 'timer' ? task.target : event.name})`)
-  }
+      details.push(`handler: ${event.provider.id}(${event.provider.id === 'timer' ? task.target : event.name})`)
+    }
 
-  if (task.provider) {
-    details.push(`file-path: ${task.provider}`)
+    if (task.provider) {
+      details.push(`file-path: ${task.provider}`)
+    }
   }
 
   return details.join(', ')

--- a/lib/server-code/services/messages-broker.js
+++ b/lib/server-code/services/messages-broker.js
@@ -142,14 +142,18 @@ class MessagesBroker extends EventEmitter {
     let msg
 
     try {
-      msg = await (this.compressionEnabled ? getter.blpopBuffer(tasksChannel, 0) : getter.blpop(tasksChannel, 0))
+      msg = this.compressionEnabled
+        ? await getter.blpopBuffer(tasksChannel, 0)
+        : await getter.blpop(tasksChannel, 0)
     } finally {
       this.getters.push(getter)
     }
 
     if (msg && msg.length) {
       try {
-        const decompressedData = this.compressionEnabled ? await decompress(msg[1]) : msg[1]
+        const decompressedData = this.compressionEnabled
+          ? await decompress(msg[1])
+          : msg[1]
 
         return JSON.parse(decompressedData)
       } catch (e) {
@@ -165,20 +169,16 @@ class MessagesBroker extends EventEmitter {
     if (this.compressionEnabled) {
       const getCompressingTime = hrtime()
 
-      logger.debug(`[${workerPID}] compress task result...`)
-
       result = await compress(result)
 
-      logger.debug(`[${workerPID}] compressed task result in ${getCompressingTime()}ms`)
+      logger.debug(`[${workerPID}] Compressed task result in ${getCompressingTime()}ms`)
     }
 
     const getPublishingTime = hrtime()
 
-    logger.debug(`[${workerPID}] publish task result to the Redis...`)
-
     await this.setter.publish(responseChannel, result)
 
-    logger.debug(`[${workerPID}] published task result to the Redis in ${getPublishingTime()}ms`)
+    logger.debug(`[${workerPID}] Published task result to the Redis in ${getPublishingTime()}ms`)
   }
 
   subscribe(event, callback) {


### PR DESCRIPTION
At this moment the JS-CodeRunner creates a new worker by demand when it receives a new task, and this is not good because it effects to the total time for each BL request. 
For creating a new worker it spends some time, and how long it depends on OS, for instance it might take from 60 to 400ms which is extremely long.  

We have to act ahead of the curve, so before a new task arrives an idle worker has to be already ready to process it.